### PR TITLE
fix(fastlane): secure temp ASC key file (0600 + delete)

### DIFF
--- a/packages/app/AWSCostMonitor/fastlane/Fastfile
+++ b/packages/app/AWSCostMonitor/fastlane/Fastfile
@@ -100,26 +100,33 @@ platform :mac do
 
   desc "Download current App Store metadata into fastlane/metadata for editing"
   lane :pull_metadata do
-    p = asc_params
-    # deliver's download runs as a CLI subcommand; invoke it with the API key so
-    # the current metadata (incl. release notes) lands in fastlane/metadata.
-    sh("cd #{File.expand_path('..', __dir__).shellescape} && " \
-       "fastlane deliver download_metadata " \
-       "--api_key_path #{asc_key_json_path.shellescape} " \
-       "--app_identifier #{APP_IDENTIFIER}")
+    # deliver's download runs as a CLI subcommand; invoke it with a temporary API
+    # key file so the current metadata (incl. release notes) lands in
+    # fastlane/metadata. The key file is created 0600 and deleted afterwards.
+    with_asc_key_json do |key_path|
+      sh("cd #{File.expand_path('..', __dir__).shellescape} && " \
+         "fastlane deliver download_metadata " \
+         "--api_key_path #{key_path.shellescape} " \
+         "--app_identifier #{APP_IDENTIFIER}")
+    end
   end
 end
 
-# Write a temporary ASC API key JSON (for CLI subcommands that take --api_key_path)
-# and return its path. Lives under fastlane/ and is gitignored.
-def asc_key_json_path
+# Write a temporary ASC API key JSON (for CLI subcommands that take --api_key_path),
+# yield its path, and always delete it afterwards. The file contains the private
+# key, so it is created owner-only (0600) and never left on disk.
+def with_asc_key_json
   p = asc_params
   path = File.expand_path("asc_api_key.json", __dir__)
-  File.write(path, JSON.pretty_generate(
-    "key_id" => p[:key_id],
-    "issuer_id" => p[:issuer_id],
-    "key" => File.read(p[:key_filepath]),
-    "in_house" => false
-  ))
-  path
+  File.open(path, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |f|
+    f.write(JSON.pretty_generate(
+      "key_id" => p[:key_id],
+      "issuer_id" => p[:issuer_id],
+      "key" => File.read(p[:key_filepath]),
+      "in_house" => false
+    ))
+  end
+  yield path
+ensure
+  File.unlink(path) if path && File.exist?(path)
 end


### PR DESCRIPTION
Addresses an automated security-review finding on `fastlane/Fastfile`.

The `pull_metadata` lane wrote the ASC API key (with the `.p8` private key contents) to `fastlane/asc_api_key.json` using default permissions and left it on disk.

Fix: a `with_asc_key_json` helper creates the file **owner-only (0600)** via `File.open`, yields the path, and **deletes it in an `ensure` block** after the `deliver` subcommand — so the plaintext key is never left on disk and never group/world-readable. (File was already gitignored; this hardens the on-disk exposure.)

Verified: `ruby -c` clean, `fastlane mac status` still loads and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)